### PR TITLE
Fix publish-runner-image.yml

### DIFF
--- a/.github/workflows/publish-runner-image.yml
+++ b/.github/workflows/publish-runner-image.yml
@@ -71,4 +71,5 @@ jobs:
           tags: "${{ steps.tags.outputs.tags }}"
 
       - name: Show Image Info
-        run: echo "Image: ${{ steps.tags.outputs.tags }}"
+        run: |
+          echo "Image: ${{ steps.tags.outputs.tags }}"


### PR DESCRIPTION
## Summary
- fix syntax error in publish-runner-image.yml by using a multiline `run`

## Testing
- `yamllint .github/workflows/publish-runner-image.yml`

------
https://chatgpt.com/codex/tasks/task_e_687c5a2aa59883219a5f4df8a8f679b2