### PR TITLE
Fix output format for discover step

### DIFF
--- a/.github/workflows/publish-runner-image.yml
+++ b/.github/workflows/publish-runner-image.yml
@@ -24,8 +24,8 @@ jobs:
         id: discover
         run: |
           files=$(find Dockerfiles -mindepth 2 -maxdepth 2 -name Dockerfile)
-          jq -n --arg files "$files" '$files | split("\n") | map(select(. != ""))' > dockerfiles.json
-          echo "matrix={\"dockerfile\":$(cat dockerfiles.json)}" >> $GITHUB_OUTPUT
+          matrix=$(echo "$files" | jq -R -s -c 'split("\n")[:-1] | {dockerfile: .}')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   build-matrix:
     needs: build-and-push


### PR DESCRIPTION
## Summary
- avoid multiline output when passing dockerfiles matrix to downstream job

## Testing
- `docker --version`
- `docker build` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687c5f0086008321ac39c624bec0727d