### PR TITLE
Fix release tag in workflow

### DIFF
--- a/.github/workflows/publish-runner-image.yml
+++ b/.github/workflows/publish-runner-image.yml
@@ -90,7 +90,7 @@ jobs:
           echo "Tag: ${{ needs.build-and-push.outputs.tag }}"
 
   release:
-    needs: build-matrix
+    needs: [build-matrix, build-and-push]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- fix access to tag output when creating a GitHub release

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687c6652fddc8321bf85a15e5f896aa2