### PR TITLE
Add resume static site

### DIFF
--- a/Dockerfiles/resume/Dockerfile
+++ b/Dockerfiles/resume/Dockerfile
@@ -1,0 +1,10 @@
+# Use a lightweight nginx base image
+FROM nginx:alpine
+
+# Copy static website content
+COPY resume/ /usr/share/nginx/html/
+
+# Expose port 80
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/resume/README.md
+++ b/resume/README.md
@@ -1,0 +1,4 @@
+# Resume Website
+
+This directory contains a simple static website that hosts my resume.
+It can be served by any static web server.

--- a/resume/index.html
+++ b/resume/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>My Resume</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>John Doe</h1>
+    <p>Software Engineer</p>
+  </header>
+  <section>
+    <h2>Experience</h2>
+    <ul>
+      <li>Company A - Senior Developer</li>
+      <li>Company B - Developer</li>
+    </ul>
+  </section>
+  <section>
+    <h2>Education</h2>
+    <ul>
+      <li>University X - B.Sc. Computer Science</li>
+    </ul>
+  </section>
+  <footer>
+    <p>Contact: <a href="mailto:john@example.com">john@example.com</a></p>
+  </footer>
+</body>
+</html>

--- a/resume/style.css
+++ b/resume/style.css
@@ -1,0 +1,20 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    line-height: 1.6;
+}
+header {
+    background: #333;
+    color: #fff;
+    padding: 20px 0;
+    text-align: center;
+}
+section {
+    margin: 20px;
+}
+footer {
+    background: #f4f4f4;
+    padding: 10px;
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- add a `resume` directory with static web assets
- add a Dockerfile at `Dockerfiles/resume` to package the site with Nginx

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d972aa61083218de56a213b74818a