### PR TITLE
Fix resume style

### DIFF
--- a/Dockerfiles/resume/resume/README.md
+++ b/Dockerfiles/resume/resume/README.md
@@ -2,4 +2,13 @@
 
 This directory contains a static website for Michael E. Faherty's resume. The content has been sanitized to remove personal contact information and can be hosted with any static web server such as nginx.
 
-Build the Docker image in the parent directory to serve the site with nginx.
+To view the site locally you can build and run the accompanying Docker image:
+
+```bash
+# from this directory
+docker build -t resume .
+docker run --rm -p 8080:8080 resume
+```
+
+Then navigate to `http://localhost:8080/` in your browser. The page uses the
+Bootswatch **lux** theme from a CDN, so Internet access is required.

--- a/Dockerfiles/resume/resume/index.html
+++ b/Dockerfiles/resume/resume/index.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Michael E. Faherty - Resume</title>
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="bootstrap.min.css">
+  <!-- Load the Bootswatch "lux" theme from a CDN for easier viewing -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/lux/bootstrap.min.css">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="bg-light">


### PR DESCRIPTION
## Summary
- load Bootswatch lux from CDN so the resume displays styled even when hosted raw
- document how to build and run the resume container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e3e548d308321a954dc95515d3e22