### PR TITLE
Fix resume header color

### DIFF
--- a/Dockerfiles/resume/resume/style.css
+++ b/Dockerfiles/resume/resume/style.css
@@ -11,6 +11,10 @@ header {
     background: linear-gradient(45deg, #4e73df, #1cc88a);
 }
 
+header h1 {
+    color: #fff;
+}
+
 .company {
     font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- ensure resume header text is white

## Testing
- `docker build -t resume .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e43c77ea88321a0b94bae413edd45