### PR TITLE
Fix resume header text color

### DIFF
--- a/Dockerfiles/resume/resume/style.css
+++ b/Dockerfiles/resume/resume/style.css
@@ -12,7 +12,7 @@ header {
 }
 
 header h1 {
-    color: #fff;
+    color: #fff !important;
 }
 
 .company {


### PR DESCRIPTION
## Summary
- ensure the header name renders in white text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e47eff89883218a9cf2cd6b30a7e9